### PR TITLE
Fixed double tap on done button crash on iOS

### DIFF
--- a/ios/Classes/ImageCropperPlugin.m
+++ b/ios/Classes/ImageCropperPlugin.m
@@ -79,7 +79,9 @@
     NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
     
     if ([[NSFileManager defaultManager] createFileAtPath:tmpPath contents:data attributes:nil]) {
-        _result(tmpPath);
+        if (_result != nil) {
+            _result(tmpPath);
+        }
     } else {
         _result([FlutterError errorWithCode:@"create_error"
                                     message:@"Temporary file could not be created"


### PR DESCRIPTION
The problem was that second tap called the same method within
cropViewControler which crashed the app since _result was nil.
Fixed by adding a nil check before calling _result function.